### PR TITLE
Fix broken hex.pm documentation link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule AlchemetricsWeb.Mixfile do
       package: package(),
       name: "Alchemetrics Web",
       docs: [
-        main: "Alchemetrics Web",
+        main: "AlchemetricsWeb",
         source_url: @project_url
       ],
       deps: deps()


### PR DESCRIPTION
Broken: https://hexdocs.pm/alchemetrics_web/Alchemetrics%20Web.html

Fixed: https://hexdocs.pm/alchemetrics_web/AlchemetricsWeb.html